### PR TITLE
Proxy is not working if port is specified

### DIFF
--- a/src/proxy_server.js
+++ b/src/proxy_server.js
@@ -37,7 +37,7 @@ function requestListener(getProxyInfo, request, response) {
 
   const socksAgent = new Socks.Agent({
     proxy,
-    target: { host: ph.host, port: ph.port },
+    target: { host: ph.hostname, port: ph.port },
   });
 
   const options = {


### PR DESCRIPTION
If port is specified, getting the following error
2019-9-16 16:44:27 - error Socket Closed on proxy 127.0.0.1:4321

It seems that if port is specified, it gets into the parsed hostname which cannot be resolved by dns.
The problem is because url.parse returns host WITH the port. The solution is to simply use hostname field

```
> ph = url.parse(`http://myserver:2222`);
Url {
  protocol: 'http:',
  slashes: true,
  auth: null,
  host: 'myserver:2222',
  port: '2222',
  hostname: 'myserver',
  hash: null,
  search: null,
  query: null,
  pathname: '/',
  path: '/',
  href: 'http://myserver:2222/' }
```
@erivni
